### PR TITLE
Change language ID to MatchOS with fallback

### DIFF
--- a/Files/M365Apps.xml
+++ b/Files/M365Apps.xml
@@ -4,7 +4,7 @@
   </Remove>
   <Add OfficeClientEdition="64" Channel="MonthlyEnterprise">
     <Product ID="O365BusinessRetail">
-      <Language ID="en-gb" />
+      <Language ID="MatchOS" Fallback="en-us" />
       <ExcludeApp ID="Access" />
       <ExcludeApp ID="Publisher" />
       <ExcludeApp ID="Groove" />


### PR DESCRIPTION
More universal way of using a configuration file